### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "moment": "^2.24.0",
     "mongoose": "^5.5.9",
     "morgan": "^1.9.1",
-    "npm": "^6.9.0",
     "passport": "^0.4.0",
     "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",


### PR DESCRIPTION

Hello ncampbell89!

It seems like you have npm as one of your (dev-) dependency in facemusicServer.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
